### PR TITLE
Add missing dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 WORKDIR /app
 RUN apt update \
-    && apt install -y --no-install-recommends git racket ca-certificates curl sqlite3 \
+    && apt install -y --no-install-recommends git racket ca-certificates curl sqlite3 libfontconfig1 libcairo2 libjpeg62-turbo libglib2.0-0 libpango-1.0-0 libpangocairo-1.0-0 \
     && apt autoclean -y \
     && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Breezewiki added a new set of dependencies.

https://gitdab.com/cadence/breezewiki/commits/branch/main

Those are needed to prevent startup errors like:

```
ffi-lib: could not load foreign library
  path: libpangocairo-1.0.so.0
  system error: libpangocairo-1.0.so.0: cannot open shared object file: No such file or directory
  context...:
   /usr/share/racket/collects/ffi/unsafe.rkt:134:0: get-ffi-lib
   body of "/usr/share/racket/pkgs/draw-lib/racket/draw/unsafe/pango.rkt"
```
